### PR TITLE
Fixed navigation initialisation bug when initialised after document load

### DIFF
--- a/src/js/components/navigation.js
+++ b/src/js/components/navigation.js
@@ -67,6 +67,11 @@ class Navigation {
             window.onload = (event) => {
                 updateMoreMenu();
             };
+
+            // If the document is already loaded, fire updateMoreMenu
+            if (document.readyState === 'complete') {
+                updateMoreMenu();
+            }
         }
     }
 


### PR DESCRIPTION
Bugfix til detfaellesdesignsystem/dkfds-components#260
Jeg har tilføjet et kald efter onload-listeneren der kalder "updateMoreMenu" hvis dokumentet allerede er indlæst.